### PR TITLE
Added Debian/Ubuntu make option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ By default, OpenMP will use the maximum number of processors it can find
 on the MPI node.  If the user wants to control the number of threads, the
 environment variable 'OMP_NUM_THREADS' may need to be set to the maximum
 number of threads per node expected.
+
+## Compile on Debian (Ubuntu)
+
+To compile QuickPIC on Debian, execute:
+
+make SYS_FX=DEBIAN
+
+This requires that libhdf5-openmpi-dev is installed as it uses the h5pfc compiler wrapper.
+

--- a/source/make.DEBIAN
+++ b/source/make.DEBIAN
@@ -1,0 +1,30 @@
+# name of the compiler 
+FC_DEBIAN = h5pfc -fopenmp
+CC_DEBIAN = gcc
+LINKER_DEBIAN = h5pfc -fopenmp -O3
+
+OPTS_DBL_DEBIAN = -O3 -fdefault-real-8 -fdefault-double-8
+OPTS_SGL_DEBIAN = -O3
+
+FORMAT_FREE_DEBIAN = -ffree-form 
+FORMAT_FIXED_DEBIAN = -ffixed-form
+
+# hdf5 libraries 
+
+HDF5_LIB =
+HDF5_INC =
+
+HDF_LIBPATH_DEBIAN =
+HDF_INCLUDE_PATH_DEBIAN =
+
+# other libs
+OTHER_LIBS_DEBIAN = 
+
+# memory options
+MEM_OPTIONS_DEBIAN = 
+
+# options for linking
+# use static libs
+STATIC_LINK_DEBIAN = 
+# use shared libs
+SHARED_LINK_DEBIAN = 


### PR DESCRIPTION
Added a make.DEBIAN file that should work on a range of distros as it uses the h5pfc wrapper rather than manually specifying HDF5 include and library paths -- these are system dependant, and tend to be very different on clusters.

To compile, use `make SYS_SFX=DEBIAN`