### PR TITLE
Dev

### DIFF
--- a/source/fpois2d_lib.f03
+++ b/source/fpois2d_lib.f03
@@ -79,7 +79,7 @@
          real, dimension(3,nyv,kxp2+1,j2blok), intent(inout) :: cu, amu
          real, dimension(nyv,kxp2+1,j2blok), intent(inout) :: bz
          complex, dimension(nyd,kxp2,j2blok), intent(in) :: ffd
-		 end subroutine
+         end subroutine
       end interface
 !
       interface

--- a/source/make.MAXWELL
+++ b/source/make.MAXWELL
@@ -1,0 +1,41 @@
+JSONFORTRAN_HOME=/home/zming/src/git/json-fortran/lib
+JSON_LIB=$(JSONFORTRAN_HOME)
+JSON_INC=$(JSONFORTRAN_HOME)/mod
+
+# name of the compiler 
+FC_MAXWELL = mpif90 -c -I$(JSON_INC) -fopenmp
+CC_MAXWELL = mpicc -c
+LINKER_MAXWELL = mpif90 -fopenmp -O3
+
+OPTS_DBL_MAXWELL = -O3 -r8
+OPTS_SGL_MAXWELL = -O3
+
+FORMAT_FREE_MAXWELL = -stand f03 -FR -Tf
+FORMAT_FIXED_MAXWELL = -FI
+
+# hdf5 libraries 
+#HDF5_HOME = /opt/hdf5/hdf5-1.10.6
+#HDF5_HOME = /data/netapp/fla/plasma/software-max/hdf5-1.12.0/intel.16.0.3.openmpi.1.10.3
+HDF5_HOME = /software/openmpi-intel/3.1.6/hdf5-1.10.6
+HDF5_LIB = $(HDF5_HOME)/lib
+HDF5_INC =$(HDF5_HOME)/include
+
+HDF_LIBPATH_MAXWELL= -L$(HDF5_LIB) \
+ -L/data/netapp/fla/plasma/software-max/szip-2.1/lib \
+ -L/usr/lib64 \
+                        -lhdf5_fortran -lhdf5_hl -lhdf5 -lz -lsz
+HDF_INCLUDE_PATH_MAXWELL= -I$(HDF5_INC) -I${HDF5_LIB} \
+  -I/data/netapp/fla/plasma/software-max/szip-2.1/include \
+              -lhdf5hl_fortran -lhdf5_fortran -lhdf5_hl -lhdf5
+
+# other libs
+OTHER_LIBS_MAXWELL = -L$(JSON_LIB) -ljsonfortran 
+
+# memory options
+MEM_OPTIONS_MAXWELL = 
+
+# options for linking
+# use static libs
+STATIC_LINK_MAXWELL = 
+# use shared libs
+SHARED_LINK_MAXWELL = 

--- a/source/make.TIANHE
+++ b/source/make.TIANHE
@@ -1,0 +1,35 @@
+JSON_INC=/PARA2/grid305/git/json-fortran/lib/mod
+JSON_LIB=/PARA2/grid305/git/json-fortran/lib
+
+FC_TIANHE = mpif90 -c -I$(JSON_INC) -fopenmp
+CC_TIANHE = mpicc -c
+LINKER_TIANHE = mpif90 -fopenmp -O3
+
+OPTS_DBL_TIANHE = -O3 -r8
+OPTS_SGL_TIANHE = -O3
+
+FORMAT_FREE_TIANHE = -stand f03 -FR -Tf 
+FORMAT_FIXED_TIANHE = -FI
+
+# hdf5 libraries 
+
+#HDF5_LIB =/WORK/app/hdf5/1.10.6-gcc-5.4.0/lib
+#HDF5_INC =/WORK/app/hdf5/1.10.6-gcc-5.4.0/include
+HDF5_ROOT = /WORK/app/hdf5/1.8.21-icc-18
+HDF5_LIB =$(HDF5_ROOT)/lib
+HDF5_INC =$(HDF5_ROOT)/include
+
+HDF_LIBPATH_TIANHE= -L$(HDF5_LIB) -lhdf5_fortran -lhdf5_hl -lhdf5 -lz 
+HDF_INCLUDE_PATH_TIANHE= -I$(HDF5_INC) -I${HDF5_LIB} -lhdf5hl_fortran -lhdf5_fortran -lhdf5_hl -lhdf5
+
+# other libs
+OTHER_LIBS_TIANHE = -L$(JSON_LIB) -ljsonfortran
+
+# memory options
+MEM_OPTIONS_TIANHE = 
+
+# options for linking
+# use static libs
+STATIC_LINK_TIANHE = 
+# use shared libs
+SHARED_LINK_TIANHE = 

--- a/source/part2d_class.f03
+++ b/source/part2d_class.f03
@@ -64,7 +64,7 @@
          integer, dimension(:,:), pointer :: ncl => null()
          integer, dimension(:,:,:), pointer :: ihole => null()
          integer, dimension(:), pointer :: kpic => null()
-         real :: xtras = 0.2
+         real :: xtras = 4.0
          logical :: list = .true.
          
          contains

--- a/source/simulation_class.f03
+++ b/source/simulation_class.f03
@@ -1,5 +1,5 @@
 ! simulation module for QuickPIC Open Source 1.0
-! update: 01/09/2018
+! update: 08/06/2020
 
       module simulation_class
 
@@ -419,6 +419,9 @@
                call this%pf(i)%p%new(input,i)
             case (3)
                allocate(fdist3d_003::this%pf(i)%p)
+               call this%pf(i)%p%new(input,i)
+            case (4)
+               allocate(fdist3d_004::this%pf(i)%p)
                call this%pf(i)%p%new(input,i)
             case (100)
                allocate(fdist3d_100::this%pf(i)%p)


### PR DESCRIPTION
A new profile code 4 is implemented, for reading the beam particles from a particle raw h5 file of a OSIRIS or QuickPIC output. The example input deck is following.

{
"simulation" : !note
{
    "nodes" : [32,1], 
    "indx" : 8,
    "indy" : 8,
    "indz" : 9,
    "box" : {
        "x" : [-4.0,4.0],
        "y" : [-4.0,4.0],
        "z" : [0.0,10.0]},
    "boundary" : "conducting",
    "n0" : 1.0e16,
    "time" : 3062.,
    "dt" : 2.0,
    "nbeams" : 1,
    "nspecies" : 1,
    "dump_restart" : false,
    "ndump_restart" : 4000,
    "read_restart" : false,
    "restart_timestep" : 1,
    "iter" : 1,
    "verbose" : 0
},

"beam" :
[
    {
    "evolution" : true,
    "profile" : 4,
    "npmax" : 4200000,
    "q" : -1.0,
    "m" : 1.0,
    "file_name" : "driver.h5",
! format can be 0 (OSIRIS, 1,2,3 correspond to z,x,y) or 1 (QuickPIC, 1,2,3 correspond to x,y,z)
    "format" : 1,
! The actual number of particles of a macro particle is (cell_volumn*n0_per_cc*1e6)*q
! which should be constant between codes, thus
! q_ratio = (cell_volumn_in_old_sim*n0_in_old_sim)/(cell_volumn_in_new_sim*n0_in_new_sim)
! /raw_sampling_ratio.
    "q_ratio" : 1.,
    "offset" : [0.0,0.0,0.0],
! Offset in x, y, z. If the h5 has OSIRIS format, z in this simulation is offset_z - z in h5.
    "quiet_start" : true,
    "diag" :
    [
        {
        "name" : ["charge"],
        "ndump" : 0
        },
        {
        "name" : ["charge"],
        "ndump" : 10,
        "slice" : [["xz", 129],["yz",129]]
        },
        {
        "name" : ["raw"],
        "ndump" : 10,
        "sample" : 1
        }
    ]    
    },
],

"species" :
[
    {
    "profile" : 0,
    "ppc" : [2,2],
    "q" : -1.0,
    "m" : 1.0,
    "density" : 1.0,
    "longitudinal_profile" : "uniform",
    "diag" :
    [
        {
        "name" : ["charge", "jx"],
        "ndump" : 0
        },
        {
        "name" : ["charge"],
        "ndump" : 10,
        "slice" : [["xz", 129],["yz",129]]
        }
    ]    
    }
],

"field" :
{
    "diag" :
    [
        {
        "name" : ["ex","ez"],
        "ndump" : 0
        },
        {
        "name" : ["ex","bx","ey","by","ez"],
        "ndump" : 10,
        "slice" : [["xz", 129],["yz", 129]]
        }
    ]    
    
}
}