### PR TITLE
Merged Viktor's updates.

### DIFF
--- a/source/part2d_lib77.f
+++ b/source/part2d_lib77.f
@@ -11,6 +11,8 @@
 ! ntmax on error, and to remove the unused argument dtc and unused local
 ! variables
 ! Added PPGRBPPUSH23L_QP to support particle reflection
+! update: 03/11/2021 by Viktor Decyk
+! Modified PPPCHECK2L to report which particle failed in error return
 !-----------------------------------------------------------------------
       subroutine PPDBLKP2L(part,kpic,npp,noff,nppmx,idimp,npmax,mx,my,  &
      &mx1,mxyp1,irc)
@@ -184,7 +186,7 @@
       if (dx.ge.edgerx) ist = 2
       if (dy.lt.edgely) ist = ist + 3
       if (dy.ge.edgery) ist = ist + 6
-      if (ist.gt.0) irc = k
+      if (ist.gt.0) irc = k + mxyp1*(j - 1)
    10 continue
    20 continue
 !$OMP END PARALLEL DO


### PR DESCRIPTION
In part2d_lib77.f, PPPCHECK2L is modified to return the particle number in addition to the tile number of a particle that was not in the correct tile.  This allows one to examine the particle coordinates of the failed particle.  If more than one particle failed, only the last one is reported.

In part2d_class.f03, in init_part2d and pmove, the x,y coordinates of a failed particle are printed out and add it to the ELOG file when a failure occurs. In init_part2d, the initial class members ntmaxp and npbmx are added by 1, to avoid possible unallocated arrays in pmove if xtras = 0.
